### PR TITLE
fix: move `typestar` to direct deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
   "sideEffects": false,
   "type": "module",
   "license": "MIT",
+  "dependencies": {
+    "typestar": "^1.8.0"
+  },
   "devDependencies": {
     "@rollup/rollup-win32-ia32-msvc": "^4.35.0",
     "@types/node": "^22.13.10",
@@ -48,7 +51,6 @@
     "eslint-config-shiny": "^4.1.0",
     "timsort": "^0.3.0",
     "typescript": "^5.8.2",
-    "typestar": "^1.8.0",
     "vitest": "^3.0.8"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      typestar:
+        specifier: ^1.8.0
+        version: 1.8.0
     devDependencies:
       '@rollup/rollup-win32-ia32-msvc':
         specifier: ^4.35.0
@@ -35,9 +39,6 @@ importers:
       typescript:
         specifier: ^5.8.2
         version: 5.8.2
-      typestar:
-        specifier: ^1.8.0
-        version: 1.8.0
       vitest:
         specifier: ^3.0.8
         version: 3.0.8(@types/node@22.13.10)(stylus@0.57.0)
@@ -3228,7 +3229,7 @@ snapshots:
 
   '@types/normalize-package-data@2.4.4': {}
 
-  '@typescript-eslint/eslint-plugin@8.26.1(@typescript-eslint/parser@8.26.1(eslint@9.22.0)(typescript@5.8.2))(eslint@9.22.0)(typescript@5.8.2)':
+  '@typescript-eslint/eslint-plugin@8.26.1(@typescript-eslint/parser@8.26.1(eslint@9.22.0)(typescript@5.8.2))(eslint@9.18.0)(typescript@5.8.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
       '@typescript-eslint/parser': 8.26.1(eslint@9.18.0)(typescript@5.8.2)
@@ -3236,7 +3237,7 @@ snapshots:
       '@typescript-eslint/type-utils': 8.26.1(eslint@9.18.0)(typescript@5.8.2)
       '@typescript-eslint/utils': 8.26.1(eslint@9.18.0)(typescript@5.8.2)
       '@typescript-eslint/visitor-keys': 8.26.1
-      eslint: 9.22.0
+      eslint: 9.18.0
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
@@ -3880,18 +3881,18 @@ snapshots:
       '@stylistic/eslint-plugin-js': 2.12.1(eslint@9.18.0)
       '@stylistic/eslint-plugin-jsx': 2.12.1(eslint@9.18.0)
       '@stylistic/eslint-plugin-ts': 2.12.1(eslint@9.18.0)(typescript@5.8.2)
-      '@typescript-eslint/eslint-plugin': 8.26.1(@typescript-eslint/parser@8.26.1(eslint@9.22.0)(typescript@5.8.2))(eslint@9.22.0)(typescript@5.8.2)
+      '@typescript-eslint/eslint-plugin': 8.26.1(@typescript-eslint/parser@8.26.1(eslint@9.22.0)(typescript@5.8.2))(eslint@9.18.0)(typescript@5.8.2)
       '@typescript-eslint/parser': 8.26.1(eslint@9.18.0)(typescript@5.8.2)
       '@vitest/eslint-plugin': 1.1.25(@typescript-eslint/utils@8.26.1(eslint@9.22.0)(typescript@5.8.2))(eslint@9.18.0)(typescript@5.8.2)(vitest@3.0.8(@types/node@22.13.10)(stylus@0.57.0))
       eslint: 9.18.0
-      eslint-import-resolver-custom-alias: 1.3.2(eslint-plugin-import@2.31.0)
-      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@9.18.0)
+      eslint-import-resolver-custom-alias: 1.3.2(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0)(typescript@5.8.2))(eslint@9.22.0))
+      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0)(typescript@5.8.2))(eslint@9.22.0))(eslint@9.18.0)
       eslint-plugin-array-func: 5.0.2(eslint@9.18.0)
       eslint-plugin-autofix: 2.2.0(eslint@9.18.0)
       eslint-plugin-compat: 6.0.2(eslint@9.18.0)
       eslint-plugin-es-x: 8.5.0(eslint@9.18.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0)(typescript@5.8.2))(eslint@9.22.0)
-      eslint-plugin-jest: 28.11.0(@typescript-eslint/eslint-plugin@8.26.1(@typescript-eslint/parser@8.26.1(eslint@9.22.0)(typescript@5.8.2))(eslint@9.18.0)(typescript@5.8.2))(eslint@9.18.0)(typescript@5.8.2)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0)(typescript@5.8.2))(eslint-import-resolver-typescript@3.7.0)(eslint@9.18.0)
+      eslint-plugin-jest: 28.11.0(@typescript-eslint/eslint-plugin@8.26.1(@typescript-eslint/parser@8.26.1(eslint@9.22.0)(typescript@5.8.2))(eslint@9.22.0)(typescript@5.8.2))(eslint@9.18.0)(typescript@5.8.2)
       eslint-plugin-jest-dom: 5.5.0(eslint@9.18.0)
       eslint-plugin-jest-formatting: 3.1.0(eslint@9.18.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.18.0)
@@ -3944,9 +3945,9 @@ snapshots:
       - typescript
       - vitest
 
-  eslint-import-resolver-custom-alias@1.3.2(eslint-plugin-import@2.31.0):
+  eslint-import-resolver-custom-alias@1.3.2(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0)(typescript@5.8.2))(eslint@9.22.0)):
     dependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0)(typescript@5.8.2))(eslint@9.22.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0)(typescript@5.8.2))(eslint-import-resolver-typescript@3.7.0)(eslint@9.18.0)
       glob-parent: 6.0.2
       resolve: 1.22.10
 
@@ -3958,7 +3959,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.18.0):
+  eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0)(typescript@5.8.2))(eslint@9.22.0))(eslint@9.18.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0
@@ -3970,7 +3971,7 @@ snapshots:
       is-glob: 4.0.3
       stable-hash: 0.0.4
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0)(typescript@5.8.2))(eslint@9.22.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0)(typescript@5.8.2))(eslint-import-resolver-typescript@3.7.0)(eslint@9.18.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -3981,7 +3982,7 @@ snapshots:
       '@typescript-eslint/parser': 8.26.1(eslint@9.18.0)(typescript@5.8.2)
       eslint: 9.18.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@9.18.0)
+      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0)(typescript@5.8.2))(eslint@9.22.0))(eslint@9.18.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -4023,7 +4024,7 @@ snapshots:
       eslint: 9.18.0
       eslint-compat-utils: 0.6.4(eslint@9.18.0)
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0)(typescript@5.8.2))(eslint@9.22.0):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0)(typescript@5.8.2))(eslint-import-resolver-typescript@3.7.0)(eslint@9.18.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -4032,7 +4033,7 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.22.0
+      eslint: 9.18.0
       eslint-import-resolver-node: 0.3.9
       eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.26.1(eslint@9.22.0)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.18.0)
       hasown: 2.0.2
@@ -4062,12 +4063,12 @@ snapshots:
     dependencies:
       eslint: 9.18.0
 
-  eslint-plugin-jest@28.11.0(@typescript-eslint/eslint-plugin@8.26.1(@typescript-eslint/parser@8.26.1(eslint@9.22.0)(typescript@5.8.2))(eslint@9.18.0)(typescript@5.8.2))(eslint@9.18.0)(typescript@5.8.2):
+  eslint-plugin-jest@28.11.0(@typescript-eslint/eslint-plugin@8.26.1(@typescript-eslint/parser@8.26.1(eslint@9.22.0)(typescript@5.8.2))(eslint@9.22.0)(typescript@5.8.2))(eslint@9.18.0)(typescript@5.8.2):
     dependencies:
       '@typescript-eslint/utils': 8.26.1(eslint@9.18.0)(typescript@5.8.2)
       eslint: 9.18.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.26.1(@typescript-eslint/parser@8.26.1(eslint@9.22.0)(typescript@5.8.2))(eslint@9.22.0)(typescript@5.8.2)
+      '@typescript-eslint/eslint-plugin': 8.26.1(@typescript-eslint/parser@8.26.1(eslint@9.22.0)(typescript@5.8.2))(eslint@9.18.0)(typescript@5.8.2)
     transitivePeerDependencies:
       - supports-color
       - typescript


### PR DESCRIPTION
The `index.d.ts` references type from the `typestar`, thus `typestar` should be a direct dependency.