### PR TITLE
1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## [1.0.5] 03-16-2025
+
+- Reduce number of used variables
+
 ## [1.0.4] 03-15-2025
 
 - Use `Uint32Array` instead of number arrays to keep track of merge run statistics

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timsort2",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "TimSort sorting revived in TypeScript",
   "types": "./index.d.ts",
   "main": "./dist/index.js",
@@ -23,8 +23,6 @@
     "compare",
     "timsort",
     "algorithm",
-    "bit",
-    "bit manipulation",
     "performance",
     "fast"
   ],


### PR DESCRIPTION
This update only reduces the number of used variables, compressing the bundle size even further and solidifying the performance boost more to the 10% - 50% mark.

Or at least I would say that. My system randomly decided to slow down BOTH packages (`timsort` and `timsort2`) by 50% while I was reducing more and more variables, code and more. It's like as if the JavaScript gods found out about my act of sin of finding a better solution than their beloved `array.sort` and decided to worsen the benefits of this package. But that won't deter me in my quest of improving this package!