### PR TITLE
fix: use typescript overload

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,5 +22,16 @@ declare module 'timsort2' {
    * @param lo - First element in the range (inclusive).
    * @param hi - Last element in the range.
    */
-  export function sort<T>(array: AnyArray<T>, compare?: Comparator<T>, lo?: number, hi?: number): AnyArray<T>
+  export function sort<T>(array: T[], compare?: Comparator<T>, lo?: number, hi?: number): T[]
+  export function sort<T extends ArrayBufferLike>(array: Int8Array<T>, compare?: Comparator<T>, lo?: number, hi?: number): Int8Array<T>
+  export function sort<T extends ArrayBufferLike>(array: Int32Array<T>, compare?: Comparator<T>, lo?: number, hi?: number): Int32Array
+  export function sort<T extends ArrayBufferLike>(array: Uint8Array<T>, compare?: Comparator<T>, lo?: number, hi?: number): Uint8Array<T>
+  export function sort<T extends ArrayBufferLike>(array: Uint16Array<T>, compare?: Comparator<T>, lo?: number, hi?: number): Uint16Array<T>
+  export function sort<T extends ArrayBufferLike>(array: Uint32Array<T>, compare?: Comparator<T>, lo?: number, hi?: number): Uint32Array<T>
+  export function sort<T extends ArrayBufferLike>(array: Float32Array<T>, compare?: Comparator<T>, lo?: number, hi?: number): Float32Array<T>
+  export function sort<T extends ArrayBufferLike>(array: Float64Array<T>, compare?: Comparator<T>, lo?: number, hi?: number): Float64Array<T>
+  export function sort<T extends ArrayBufferLike>(array: Uint8ClampedArray<T>, compare?: Comparator<T>, lo?: number, hi?: number): Uint8ClampedArray<T>
+  export function sort<T extends ArrayBufferLike>(array: Uint8ClampedArray<T>, compare?: Comparator<T>, lo?: number, hi?: number): Uint8ClampedArray<T>
+  export function sort<T extends ArrayBufferLike>(array: BigInt64Array<T>, compare?: Comparator<T>, lo?: number, hi?: number): BigInt64Array<T>
+  export function sort<T extends ArrayBufferLike>(array: BigUint64Array<T>, compare?: Comparator<T>, lo?: number, hi?: number): BigUint64Array<T>
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,19 @@ export function alphabeticalCompare(a: any, b: any): number {
  * @param lo - First element in the range (inclusive).
  * @param hi - Last element in the range.
  */
-export function sort<T>(array: AnyArray<T>, compare: Comparator<T> = alphabeticalCompare, lo = 0, hi = array.length): AnyArray<T> {
+export function sort<T>(array: T[], compare?: Comparator<T>, lo?: number, hi?: number): T[]
+export function sort<T extends ArrayBufferLike>(array: Int8Array<T>, compare?: Comparator<T>, lo?: number, hi?: number): Int8Array<T>
+export function sort<T extends ArrayBufferLike>(array: Int32Array<T>, compare?: Comparator<T>, lo?: number, hi?: number): Int32Array
+export function sort<T extends ArrayBufferLike>(array: Uint8Array<T>, compare?: Comparator<T>, lo?: number, hi?: number): Uint8Array<T>
+export function sort<T extends ArrayBufferLike>(array: Uint16Array<T>, compare?: Comparator<T>, lo?: number, hi?: number): Uint16Array<T>
+export function sort<T extends ArrayBufferLike>(array: Uint32Array<T>, compare?: Comparator<T>, lo?: number, hi?: number): Uint32Array<T>
+export function sort<T extends ArrayBufferLike>(array: Float32Array<T>, compare?: Comparator<T>, lo?: number, hi?: number): Float32Array<T>
+export function sort<T extends ArrayBufferLike>(array: Float64Array<T>, compare?: Comparator<T>, lo?: number, hi?: number): Float64Array<T>
+export function sort<T extends ArrayBufferLike>(array: Uint8ClampedArray<T>, compare?: Comparator<T>, lo?: number, hi?: number): Uint8ClampedArray<T>
+export function sort<T extends ArrayBufferLike>(array: Uint8ClampedArray<T>, compare?: Comparator<T>, lo?: number, hi?: number): Uint8ClampedArray<T>
+export function sort<T extends ArrayBufferLike>(array: BigInt64Array<T>, compare?: Comparator<T>, lo?: number, hi?: number): BigInt64Array<T>
+export function sort<T extends ArrayBufferLike>(array: BigUint64Array<T>, compare?: Comparator<T>, lo?: number, hi?: number): BigUint64Array<T>
+export function sort<T>(array: AnyArray<T>, compare = alphabeticalCompare, lo = 0, hi = array.length): AnyArray<T> {
   let remaining = hi - lo
   // A range of only one element is already sorted.
   if (remaining < 2) return array


### PR DESCRIPTION
```ts
export function sort<T>(array: AnyArray<T>, compare = alphabeticalCompare, lo = 0, hi = array.length): AnyArray<T>
```

This type is not strict and constrained enough. TypeScript would assume the return type of `sort([1, 2, 3])` would be either `Array<number>`, `Uint8Array<number>`, `Int8Array<number>`, and so on, where the truth is the return type is the same as the input type.

The PR introduces type overload (https://www.typescriptlang.org/docs/handbook/2/functions.html#function-overloads) to type more strictly.